### PR TITLE
Removed form validation (as telephone) to allow it to be set to AlphaNum...

### DIFF
--- a/Component/Validate.php
+++ b/Component/Validate.php
@@ -43,8 +43,7 @@ class Validate
      */
     private static $_meta = array(
         'sendMessage' => array(
-            'to' => 'required|telephone',
-            'from' => 'telephone'
+            'to' => 'required|telephone'
         ),
         'getBalance' => array(
         ),


### PR DESCRIPTION
If you get Clickatell to agree an AlphaNumeric CallerID you need to be able to set it. (This is my first pull request so go easy on me if I have done it wrong, just trying to help!)
