### PR TITLE
Update Api.php

### DIFF
--- a/Api/Api.php
+++ b/Api/Api.php
@@ -62,7 +62,9 @@ abstract class Api
         'concatenation' => 'concat',
         'max_credits' => 'max_credits',
         'required_features' => 'req_feat',
-        'unicode' => 'unicode'
+        'unicode' => 'unicode',
+        'mobile_orginated' => 'mo',
+        'client_message_id' => 'cliMsgId'
     );
 
     /**


### PR DESCRIPTION
Can you please add these changes so that Clickatell can provide us with a from number in cases where we have to use the "mo" parameter.  And also the "cliMsgId" parameter so we can assign every sms a unique key so when Clickatell does the callback it is easier to find the specific sms.

Or alternatively can you please update the code so that when we use the "request" event and inject additional parameters, it persists through to the final request. At this moment the "request" event provided can only be used for logging or debugging since all changes are ignored before the request is sent.
