### PR TITLE
Make 'network' an optional parameter. Fix #23

### DIFF
--- a/src/Callback.php
+++ b/src/Callback.php
@@ -101,7 +101,6 @@ class Callback
                 'from',
                 'to',
                 'timestamp',
-                'network',
                 'text'
             )
         );
@@ -109,7 +108,8 @@ class Callback
         $optional = array_flip(
             array(
                 'charset',
-                'udh'
+                'udh',
+                'network'
             )
         );
 

--- a/test/CallbackTest.php
+++ b/test/CallbackTest.php
@@ -108,8 +108,8 @@ class CallbackTest extends PHPUnit_Framework_TestCase
             'from' => 3,
             'to' => 4,
             'timestamp' => 5,
-            'network' => 6,
-            'text' => 7
+            'text' => 7,
+            'network' => 6
         );
 
         Callback::parseMoCallback(function ($args) use (&$data) {


### PR DESCRIPTION
Change network to an optional parameter. According to the Clickatell documentation the network, udh and charset parameters are optional and will only be populated under certain circumstances.